### PR TITLE
Fix type error on python 3.9+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,25 @@
+### PyCharm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+/.idea
+/.code
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+*.pyc
+
+# Distribution / packaging
 dist/
-venv/
+
+# Unit test / coverage reports
 .mypy_cache/
 .pytest_cache/
 .coverage
 coverage.xml
 htmlcov/
 tests/data/
-*.pyc
+
+# Environments
+venv/

--- a/distiller/nodes.py
+++ b/distiller/nodes.py
@@ -330,4 +330,7 @@ def load_nodes_types_from_module(module: Optional[ModuleType]) -> Iterator[NodeT
 
 
 def _is_node_type(obj: Any) -> bool:
-    return isclass(obj) and issubclass(obj, Node) and obj is not Node
+    try:
+        return isclass(obj) and issubclass(obj, Node) and obj is not Node
+    except TypeError:
+        return False


### PR DESCRIPTION
Started from python 3.9 we can use standard collections in typing:
https://docs.python.org/3.9/whatsnew/3.9.html#type-hinting-generics-in-standard-collections

Before 3.9 we must write like this:
```python
from typing import List

list_obj: List[str] = ['1']
```

From 3.9 we can write:
```python
list_obj: list[str] = ['1']
```

And you have code like this:
```python
def _is_node_type(obj: Any) -> bool:
    return isclass(obj) and issubclass(obj, Node) and obj is not Node
```

And this code apply for all objects in module. 

But we have a problem, because `issubclass` with generic raise `TypeError`.
Your code works in python 3.8 and lower because `isclass(typing.List[str]) -> False`, but for list it return `isclass(list[str]) -> True`

In this PR I fixed it. And made some refactor in gitignote file